### PR TITLE
Add more verbosity to makedok script

### DIFF
--- a/inaugurator/makedok.py
+++ b/inaugurator/makedok.py
@@ -22,9 +22,16 @@ def deviceSizeGB(device):
 
 def transferOsmosisLabel(label, mountPoint):
     objectStores = sh.run("solvent printobjectstores").strip()
-    sh.run(
-        "osmosis transfer %s --transferDestination=%s/osmosisobjectstore --objectStores=%s "
-        "--putIfMissing" % (label, mountPoint, objectStores))
+    tmplocation = tempfile.mkdtemp()
+    store_dirname = "osmosisobjectstore"
+
+    logging.info("Transferring to tmp dir")
+    sh.run("osmosis transfer %s --transferDestination=%s/%s --objectStores=%s "
+           "--putIfMissing" % (label, tmplocation, store_dirname,
+                               objectStores))
+    logging.info("copying to DOK. This might take a while.")
+    shutil.copytree("%s/%s" % (tmplocation, store_dirname),
+                    "%s/%s" % (mountPoint, store_dirname))
 
 
 def installInaugurator(device, mountPoint):


### PR DESCRIPTION
In makedok.py, we use osmosis to transfer a label into the DOK.
This takes a long time (about 6minutes) because a rootfs file is about 3GB.
This commit splits this stage into 2:
    1. osmosis transfer
    2. copying to DOK - which can take quite a while.