### PR TITLE
Add StopListeningOnID functionality to Inaugurator-server

### DIFF
--- a/inaugurator/server/idlistener.py
+++ b/inaugurator/server/idlistener.py
@@ -1,0 +1,59 @@
+import logging
+
+_logger = logging.getLogger('inaugurator.server')
+
+
+def statusExchange(id):
+    return "inaugurator_status__%s" % id
+
+
+class IDListener:
+    def __init__(self, id, callback, channel):
+        self._channel = channel
+        self._id = id
+        self._statusQueue = None
+        self._callback = callback
+        self._notListeningAnymore = False
+        self._channel.exchange_declare(
+            self._onExchangeDeclared, exchange=statusExchange(self._id), type='fanout')
+
+    def stopListening(self):
+        if self._notListeningAnymore:
+            _logger.error("Tried to stop listening on an id %(id)s which is not listened to",
+                          dict(id=self._id))
+            return
+        self._notListeningAnymore = True
+        self._callback = None
+        self._freeQueue()
+
+    def _onExchangeDeclared(self, unusedFrame):
+        if self._notListeningAnymore:
+            return
+        self._channel.queue_declare(self._onQueueDeclared, exclusive=True)
+
+    def _onQueueBind(self, myQueue):
+        if self._notListeningAnymore or self._statusQueue is None:
+            return
+        self._channel.basic_consume(self._sendDataToCallback, queue=self._statusQueue, no_ack=True)
+
+    def _sendDataToCallback(self, *data):
+        if self._notListeningAnymore:
+            return
+        try:
+            assert self._callback is not None
+            self._callback(*data)
+        except:
+            logging.exception("While handling data from status queue for id %(id)s", dict(id=self._id))
+
+    def _onQueueDeclared(self, methodFrame):
+        self._statusQueue = methodFrame.method.queue
+        if self._notListeningAnymore:
+            self._freeQueue()
+            return
+        self._channel.queue_bind(self._onQueueBind, exchange=statusExchange(self._id),
+                                 queue=self._statusQueue)
+
+    def _freeQueue(self):
+        if self._statusQueue is None:
+            return
+        self._channel.queue_delete(None, queue=self._statusQueue)

--- a/inaugurator/tests/common.py
+++ b/inaugurator/tests/common.py
@@ -1,0 +1,92 @@
+import mock
+
+
+class MethodFrameMock:
+    class Method(object):
+        def __init__(self, **kwargs):
+            for key, value in kwargs.iteritems():
+                setattr(self, key, value)
+
+    def __init__(self, **kwargs):
+        self.method = self.Method(**kwargs)
+
+
+class PikaChannelMock:
+    MOCK_SUPPORTS_NAMED_QUEUE = False
+
+    def __init__(self, test):
+        self.declaredQueues = set()
+        self.declaredQueuesCallbacks = dict()
+        self.queue_bind = mock.Mock()
+        self.exchange_declare = mock.Mock()
+        self.basic_consume = mock.Mock()
+        self.requests = list()
+        self.test = test
+        self.tempQueueCounter = 0
+
+    def queue_declare(self, callback, **kwargs):
+        self.test.assertNotIn("queue", kwargs)
+        if not self.MOCK_SUPPORTS_NAMED_QUEUE:
+            assert "queue" not in kwargs
+        self.requests.append(("declare", callback))
+
+    def queue_delete(self, callback, queue):
+        self.test.assertIn(queue, self.declaredQueues)
+        self.requests.append(("delete", queue, callback))
+
+    def getBasicConsumeCallback(self):
+        return self._getCallback(self.basic_consume)
+
+    def getQueueBindCallback(self):
+        return self._getCallback(self.queue_bind)
+
+    def answerQueueDeclare(self):
+        self._handleOneQueueDeclarationRequest()
+        queue = next(iter(self.declaredQueues))
+        queueDeclaredCallback = self.declaredQueuesCallbacks[queue]
+        queueDeclaredCallback(MethodFrameMock(queue=queue))
+        return queue
+
+    def answerQueueDelete(self, expectedDeletedQueue):
+        deletedQueue, queueDeletedCallback = self._handleOneQueueDeletionRequest()
+        self.test.assertEquals(deletedQueue, expectedDeletedQueue)
+        if queueDeletedCallback is not None:
+            queueDeletedCallback()
+
+    def answerExchangeDeclare(self, expectedStatusExchange):
+
+        def Any(cls):
+            class Any(cls):
+                def __eq__(self, other):
+                    return True
+            return Any()
+
+        self.exchange_declare.assert_called_with(Any(int), exchange=expectedStatusExchange, type='fanout')
+        statusExchangeDeclaredCallback = self._getCallback(self.exchange_declare)
+        statusExchangeDeclaredCallback(MethodFrameMock())
+
+    def _popFromRequestsQueue(self, expectedRequestType):
+        request = self.requests.pop(0)
+        self.test.assertEquals(request[0], expectedRequestType)
+        return request[1:]
+
+    def _handleOneQueueDeclarationRequest(self):
+        (queueDeclaredCallback,) = self._popFromRequestsQueue(expectedRequestType="declare")
+        queue = 'some-status-queue_%(tempQueueCounter)s' % (dict(tempQueueCounter=self.tempQueueCounter))
+        assert queue not in self.declaredQueues
+        self.tempQueueCounter += 1
+        self.test.assertNotIn(queue, self.declaredQueuesCallbacks)
+        self.declaredQueues.add(queue)
+        self.declaredQueuesCallbacks[queue] = queueDeclaredCallback
+
+    def _handleOneQueueDeletionRequest(self):
+        queue, callback = self._popFromRequestsQueue(expectedRequestType="delete")
+        self.declaredQueues.remove(queue)
+        return queue, callback
+
+    def _getCallback(self, mockObj):
+        self.test.assertTrue(mockObj.called)
+        callback = mockObj.call_args[0][0]
+        self.test.assertIsNotNone(callback)
+        mockObj.reset_mock()
+        return callback

--- a/inaugurator/tests/test_idlistener.py
+++ b/inaugurator/tests/test_idlistener.py
@@ -1,0 +1,126 @@
+import os
+import sys
+import mock
+import logging
+import unittest
+assert 'usr' not in __file__.split(os.path.sep)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+from inaugurator.server import idlistener
+from inaugurator.tests.common import PikaChannelMock
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.consumeCallback = mock.Mock()
+        self.channel = PikaChannelMock(self)
+        self.expectedStatusExchange = idlistener.statusExchange("delta-foxtrot")
+        self.tested = idlistener.IDListener("delta-foxtrot", self.consumeCallback, self.channel)
+
+    def test_Listen(self):
+        self.validateListenHappyFlow()
+
+    def test_StopListening(self):
+        queue = self.validateListenHappyFlow()
+        self.tested.stopListening()
+        self.validateOneStatusQueueIsAllocated(queue, allowOtherRequests=True)
+        self.channel.answerQueueDelete(queue)
+        self.validateNoStatusQueueIsAllocated()
+        self.validateMessages(self.basicConsumeCallback, isArrivalExpected=False)
+
+    def test_StopListeningBeforeExchangeDeclared(self):
+        self.validateNoStatusQueueIsAllocated()
+        self.tested.stopListening()
+        self.validateNoStatusQueueIsAllocated()
+        self.channel.answerExchangeDeclare(self.expectedStatusExchange)
+        self.validateNoStatusQueueIsAllocated()
+
+    def test_StopListeningBeforeQueueDeclared(self):
+        self.validateListenFlowUntilStatusQueueDeclare()
+        self.validateOneStatusQueueIsAllocating()
+        self.tested.stopListening()
+        self.validateOneStatusQueueIsAllocating()
+        queue = self.channel.answerQueueDeclare()
+        self.validateOneStatusQueueIsAllocated(queue, allowOtherRequests=True)
+        self.channel.answerQueueDelete(queue)
+        self.validateNoStatusQueueIsAllocated()
+
+    def test_StopListeningBeforeQueueBinded(self):
+        self.validateListenFlowUntilStatusQueueDeclare()
+        queue = self.channel.answerQueueDeclare()
+        self.validateOneStatusQueueIsAllocated(queue)
+        self.tested.stopListening()
+        self.validateOneStatusQueueIsAllocated(queue, allowOtherRequests=True)
+        queueBindCallback = self.channel.getQueueBindCallback()
+        queueBindCallback(queue)
+        self.validateOneStatusQueueIsAllocated(queue, allowOtherRequests=True)
+        self.channel.answerQueueDelete(queue)
+        self.validateNoStatusQueueIsAllocated(allowOtherRequests=True)
+
+    def test_StopListeningTwice(self):
+        queue = self.validateListenHappyFlow()
+        self.tested.stopListening()
+        self.channel.answerQueueDelete(queue)
+        self.validateNoStatusQueueIsAllocated()
+        self.tested.stopListening()
+        self.validateNoStatusQueueIsAllocated()
+
+    def test_MoreThanOneInstance(self):
+        for i in xrange(10):
+            queue = self.validateListenHappyFlow()
+            self.tested.stopListening()
+            self.channel.answerQueueDelete(queue)
+            self.validateNoStatusQueueIsAllocated()
+            self.tested = idlistener.IDListener("delta-foxtrot", self.consumeCallback, self.channel)
+        self.validateNoStatusQueueIsAllocated()
+
+    def validateListenFlowUntilStatusQueueDeclare(self):
+        self.validateNoStatusQueueIsAllocated()
+        self.channel.answerExchangeDeclare(self.expectedStatusExchange)
+        self.validateOneStatusQueueIsAllocating()
+
+    def validateListenFlowAfterQueueDeclare(self, queue):
+        queueBindCallback = self.channel.getQueueBindCallback()
+        queueBindCallback(queue)
+        self.basicConsumeCallback = self.channel.getBasicConsumeCallback()
+        self.validateMessages(self.basicConsumeCallback)
+        self.validateOneStatusQueueIsAllocated(queue)
+
+    def validateListenHappyFlow(self):
+        self.validateListenFlowUntilStatusQueueDeclare()
+        queue = self.channel.answerQueueDeclare()
+        self.validateListenFlowAfterQueueDeclare(queue)
+        self.validateOneStatusQueueIsAllocated(queue)
+        return queue
+
+    def validateMessages(self, basicConsumeCallback, isArrivalExpected=True):
+        message = 'I am a cool message.'
+        basicConsumeCallback(message)
+        self.assertEquals(self.consumeCallback.called, isArrivalExpected)
+        self.consumeCallback.reset_mock()
+
+    def validateOneStatusQueueIsAllocated(self, queue, allowOtherRequests=False):
+        self.assertEquals(set([queue]), self.channel.declaredQueues)
+        if not allowOtherRequests:
+            self.assertFalse(self.channel.requests)
+
+    def validateOneStatusQueueIsAllocating(self, allowDeleteRequests=False):
+        self.assertEquals(len(self.channel.requests), 1)
+        self.assertEquals(self.channel.requests[0][0], "declare")
+        if not allowDeleteRequests:
+            self.assertFalse(self.channel.declaredQueues)
+
+    def validateNoStatusQueueIsAllocated(self, allowOtherRequests=False):
+        self.assertFalse(self.channel.declaredQueues)
+        if not allowOtherRequests:
+            self.assertFalse(self.channel.requests)
+            self.assertFalse(self.channel.queue_bind.called)
+            self.assertFalse(self.channel.basic_consume.called)
+
+
+if __name__ == '__main__':
+    _logger = logging.getLogger("inaugurator.server")
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    _logger.addHandler(handler)
+    _logger.setLevel(logging.DEBUG)
+    unittest.main()

--- a/inaugurator/tests/test_server.py
+++ b/inaugurator/tests/test_server.py
@@ -5,6 +5,8 @@ import time
 import subprocess
 import os
 import sys
+import functools
+import threading
 assert 'usr' not in __file__.split(os.path.sep)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from inaugurator.server import server
@@ -16,6 +18,8 @@ config.AMQP_URL = "amqp://guest:guest@localhost:%d/%%2F" % config.PORT
 
 
 class Test(unittest.TestCase):
+    UNREPORTED_PROGRESS_MESSAGE = "unreportedProgressMessage"
+
     def setUp(self):
         output = subprocess.check_output(["ps", "-Af"])
         if 'beam.smp' in output:
@@ -26,6 +30,8 @@ class Test(unittest.TestCase):
         self.checkInCallbackArguments = []
         self.doneCallbackArguments = []
         self.progressCallbackArguments = []
+        self.progressWaitEvents = dict()
+        self.unreportedProgressMessageEvent = None
 
     def tearDown(self):
         self.rabbitMQWrapper.cleanup()
@@ -42,11 +48,19 @@ class Test(unittest.TestCase):
         self.doneCallbackArguments.append(args)
 
     def progressCallback(self, *args):
+        message = args[1]
+        if message == self.UNREPORTED_PROGRESS_MESSAGE:
+            self.unreportedProgressMessageEvent.set()
+            return
         self.progressCallbackArguments.append(args)
 
     def sendCheckIn(self, id):
         talk = talktoserver.TalkToServer(config.AMQP_URL, id)
         talk.checkIn()
+
+    def sendProgress(self, id, message):
+        talk = talktoserver.TalkToServer(config.AMQP_URL, id)
+        talk.progress(message)
 
     def assertEqualsWithinTimeout(self, callback, expected, interval=0.1, timeout=3):
         before = time.time()
@@ -56,6 +70,13 @@ class Test(unittest.TestCase):
                     return
             except:
                 time.sleep(interval)
+        self.assertEquals(callback(), expected)
+
+    def assertEqualsDuringPeriod(self, callback, expected, interval=0.1, period=1):
+        before = time.time()
+        while time.time() < before + period:
+            self.assertEquals(callback(), expected)
+            time.sleep(interval)
         self.assertEquals(callback(), expected)
 
     def test_CheckIn(self):
@@ -69,6 +90,59 @@ class Test(unittest.TestCase):
         finally:
             tested.close()
 
+    def test_StopListening(self):
+        tested = server.Server(self.checkInCallback, self.doneCallback, self.progressCallback)
+        try:
+            tested.listenOnID("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            self.invokeStopListeningAndWaitTillDone(tested, "yuvu")
+            self.validateCheckInDoesNotWork(tested, "yuvu")
+            tested.listenOnID("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            self.assertEquals(self.doneCallbackArguments, [])
+            self.assertEquals(self.progressCallbackArguments, [])
+        finally:
+            tested.close()
+
+    def test_StopListeningDoesNotAffectAnotherServer(self):
+        tested = server.Server(self.checkInCallback, self.doneCallback, self.progressCallback)
+        try:
+            tested.listenOnID("jakarta")
+            tested.listenOnID("yuvu")
+            self.sendCheckIn("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            self.validateCheckIn(tested, "jakarta")
+            self.invokeStopListeningAndWaitTillDone(tested, "yuvu")
+            self.validateCheckIn(tested, "jakarta")
+            self.validateCheckInDoesNotWork(tested, "yuvu")
+            tested.listenOnID("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            self.validateCheckIn(tested, "jakarta")
+            self.assertEquals(self.doneCallbackArguments, [])
+            self.assertEquals(self.progressCallbackArguments, [])
+        finally:
+            tested.close()
+
+    def test_StopListeningOnAnIDWhichIsNotListenedTo(self):
+        tested = server.Server(self.checkInCallback, self.doneCallback, self.progressCallback)
+        try:
+            self.invokeStopListeningAndWaitTillDone(tested, "yuvu")
+            self.validateCheckInDoesNotWork(tested, "yuvu")
+        finally:
+            tested.close()
+
+    def test_ListenTwiceOnSameID(self):
+        tested = server.Server(self.checkInCallback, self.doneCallback, self.progressCallback)
+        try:
+            tested.listenOnID("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            tested.listenOnID("yuvu")
+            self.validateCheckIn(tested, "yuvu")
+            self.invokeStopListeningAndWaitTillDone(tested, "yuvu")
+            self.validateCheckInDoesNotWork(tested, "yuvu")
+        finally:
+            tested.close()
+
     def test_SendCommand(self):
         tested = server.Server(self.checkInCallback, self.doneCallback, self.progressCallback)
         try:
@@ -78,6 +152,36 @@ class Test(unittest.TestCase):
             self.assertEquals(talk.label(), "fake label")
         finally:
             tested.close()
+
+    def checkInAndCheckIfMessageArrived(self, id):
+        self.sendCheckIn(id)
+        return (id,) in self.checkInCallbackArguments
+
+    def validateCheckIn(self, tested, id):
+        self.assertEqualsWithinTimeout(functools.partial(self.checkInAndCheckIfMessageArrived, id), True)
+        self.waitTillStatusQueueIsCleanByAbusingProgressCallbacks(id, tested)
+        self.checkInCallbackArguments = []
+
+    def validateCheckInDoesNotWork(self, tested, id):
+        self.assertEqualsDuringPeriod(functools.partial(self.checkInAndCheckIfMessageArrived, id), False)
+
+    def waitTillStatusQueueIsCleanByAbusingProgressCallbacks(self, idWhichIsListenedTo, tested):
+        self.unreportedProgressMessageEvent = threading.Event()
+        self.sendProgress(idWhichIsListenedTo, self.UNREPORTED_PROGRESS_MESSAGE)
+        if not self.unreportedProgressMessageEvent.wait(timeout=1):
+            raise AssertionError("Progress callback was not invoked at time")
+
+    def waitTillAllCommandsWereExecutedByTheServer(self, tested):
+        self.auxIDCounter = 0
+        auxID = "IDWhichIsUsedToValidateThatTheServerHasFinishedAllPendingCommands_%(counter)s" % \
+            dict(counter=self.auxIDCounter)
+        self.auxIDCounter += 1
+        tested.listenOnID(auxID)
+        self.validateCheckIn(tested, auxID)
+
+    def invokeStopListeningAndWaitTillDone(self, tested, id):
+        tested.stopListeningOnID(id)
+        self.waitTillAllCommandsWereExecutedByTheServer(tested)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This includes a new module "idlistener", its unittests, and more tests in test_server.py for the stop-listening functionality.