### PR TITLE
Updated osmosis upseto-deps to latest master

### DIFF
--- a/upseto.manifest
+++ b/upseto.manifest
@@ -1,3 +1,3 @@
 requirements:
-- hash: 1f8ff2c0ab62df7ebcb572500e6df4aa9224baab
+- hash: d08e2347e2d6f33d3d63ea70eb00dff90130df06
   originURL: https://github.com/Stratoscale/osmosis.git


### PR DESCRIPTION
osmosis changed to more verbosity on fails on Jun 14, but the upseto dep is one commit back.
I suggest forwarding the dependency.
