### PR TITLE
Guymenahem/nk 33

### DIFF
--- a/Dockerfile.build-inaugurator
+++ b/Dockerfile.build-inaugurator
@@ -36,7 +36,7 @@ RUN rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org && \
     yum install -y kmod-cciss && \
     yum -y clean all
 
-RUN pip install pep8 pika>=0.10.0
+RUN pip install pep8 pika==0.11.2
 
 # Edit sudoers file to avoid error: sudo: sorry, you must have a tty to run sudo
 RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers

--- a/Dockerfile.build-inaugurator
+++ b/Dockerfile.build-inaugurator
@@ -1,7 +1,5 @@
-define(`KERNEL_VERSION', esyscmd(`printf \`\`%s\'\' "$KERNEL_VERSION"'))
-
-FROM centos:7.5.1804
-MAINTAINER korabel@stratoscale.com
+FROM centos:7.6.1810
+MAINTAINER guymenahem@neokarm.com
 
 # Install other tools
 RUN yum update -y && \
@@ -44,7 +42,7 @@ RUN pip install pep8 pika>=0.10.0
 RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
 
 # Install busybox with a Fedora RPM since there's no such package for Centos 7
-RUN curl ftp://195.220.108.108/linux/fedora/linux/releases/28/Everything/x86_64/os/Packages/b/busybox-1.26.2-3.fc27.x86_64.rpm -o temp && \
+RUN curl ftp://195.220.108.108/linux/fedora/linux/releases/31/Everything/x86_64/os/Packages/b/busybox-1.30.1-2.fc31.x86_64.rpm -o temp && \
     rpm -ivh temp && \
     rm temp
 

--- a/Makefile.build
+++ b/Makefile.build
@@ -1,4 +1,4 @@
-KERNEL_VERSION = 3.10.0-862.6.3.el7.x86_64
+KERNEL_VERSION = 3.10.0-1127.8.2.el7.x86_64
 INAUGURATOR_VERSION=$(shell python setup.py --version)
 PYTHON_DIST_FILENAME=dist/inaugurator-${INAUGURATOR_VERSION}.linux-x86_64.tar.gz
 KERNEL_IMAGE_PATH=/boot/vmlinuz-$(KERNEL_VERSION)

--- a/sh/list_storage_and_network_driver_names.sh
+++ b/sh/list_storage_and_network_driver_names.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #list the drivers for the fat version
-BLACKLIST='-e bfa -e csiostor -e cxgb4 -e bna -e aic94xx'
+BLACKLIST='-e bfa -e csiostor -e cxgb4 -e bna -e aic94xx -e r8169'
 KERNEL_VERSION=$1
 set -e
 find /lib/modules/$KERNEL_VERSION/kernel/drivers/net/ethernet /lib/modules/$KERNEL_VERSION/kernel/drivers/scsi /lib/modules/$KERNEL_VERSION/kernel/drivers/nvme /lib/modules/$KERNEL_VERSION/kernel/drivers/message /lib/modules/$KERNEL_VERSION/kernel/weak-updates/cciss -type f -printf '%f\n' | sed 's/\.ko$//' | sed 's/\.ko.xz$//' | grep -v $BLACKLIST

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -1,3 +1,3 @@
 registry: rackattack-nas.dc1:5000
 build-container-image: build-inaugurator
-build-container-tag: "1.5.4"
+build-container-tag: "1.5.6"


### PR DESCRIPTION
NK-33
Update Kernel version of Spout & Inaugurator to 3.10.0-1127.8.2

Tests:
dok - http://jenkins.dc1.strato:8080/job/make-symphony/13733/ - Success
pxe - http://jenkins.dc1.strato:8080/job/make-symphony/13735/ - Success
iso - http://jenkins.dc1.strato:8080/job/make-symphony/13738/ - Success
qcow - http://jenkins.dc1.strato:8080/job/make-symphony/13736/ - Success
vmdk - http://jenkins.dc1.strato:8080/job/make-symphony/13737/ - Success
upgrade (wrong job name )- http://jenkins.dc1.strato:8080/job/make-symphony/13739/ - Success