### PR TITLE
NK-346 add nvme partition table naming support

### DIFF
--- a/inaugurator/partitiontable.py
+++ b/inaugurator/partitiontable.py
@@ -390,7 +390,11 @@ class PartitionTable:
     def _getPartitionPath(self, partitionPurpose):
         partitionIdx = self._physicalPartitionsOrder.index(partitionPurpose)
         partitionNr = partitionIdx + 1
-        return "%(device)s%(partitionNr)s" % dict(device=self._device, partitionNr=partitionNr)
+
+        if "nvme" in self._device:
+            return "%(device)sp%(partitionNr)s" % dict(device=self._device, partitionNr=partitionNr)
+        else:
+            return "%(device)s%(partitionNr)s" % dict(device=self._device, partitionNr=partitionNr)
 
     def getBootPartitionPath(self):
         return self._getPartitionPath("boot")


### PR DESCRIPTION
NVME partition table have a different naming convention than HDD, SDD and vd* (emulated devices).

sda1 - 1 for first partition
nvme0n1p1 - p1 for first partition

Tested with hot-fix on servers with nvme devices.